### PR TITLE
feat: On-demand multi-scale V-recovery detector for S-order gating (ADR 020)

### DIFF
--- a/docs/decisions/020-v-recovery-detector.md
+++ b/docs/decisions/020-v-recovery-detector.md
@@ -1,0 +1,117 @@
+# ADR 020: On-Demand Multi-Scale V-Recovery Detector for Sell-to-Open Gating
+
+**Date:** 2026-05-23  
+**Status:** Proposed for review — implementation in PR #XXX (branch `feature/v-recovery-detector-v1`)
+
+## Context
+
+When a bot strategy is about to submit a sell-to-open (short) order it must have the option to refuse if price is currently in the recovery phase of one or more V-shaped bottoms. The same logic applies symmetrically for buy-to-open orders on inverted-V recoveries.
+
+Requirements collected during design discussions:
+
+- The detector is **on-demand only** — it is invoked by the bot immediately before order submission, not on every bar.
+- Maximum lookback is a **hard internal cap of 48 hours** (not supplied by the caller and not tunable via settings.yaml).
+- The detector must surface **multiple** Vs at different scales inside the 48-hour window (a 40-minute V and a 7-hour V can both be active and must both be reported).
+- **Flattish / slow recoveries must qualify**. No momentum, slope, consecutive-up-bar, or "sharp bounce" requirements are allowed. A gradual grind higher after a material drop is still a V-recovery for gating purposes.
+- Rich **diagnostics** must be produced for the just-completed bar so the operator can see exactly why a short was blocked:
+  ```
+  V: 09:15(s38), 11:42(m61), 14:03(L29)
+  ```
+  Each entry shows the trough timestamp (HH:mm) and a strength token that encodes both **depth** of the impulse leg and **recovery ratio** achieved so far.
+- High recall is explicitly preferred: it is acceptable to skip some valid short setups to avoid entering during any detected V-recovery.
+
+The implementation must be a fresh module. It deliberately does not reuse or extend any existing pivot detection, fuzzy lines, regime classifier, trajectory curves, or SR fan code.
+
+## Decision
+
+Introduce a new, self-contained, pure module:
+
+**`ib_trader/bots/strategies/v_recovery.py`**
+
+The public surface for v1 is intentionally small:
+
+```python
+def detect_v_recoveries(
+    bars: list[dict],
+    *,
+    min_depth_pct: float = 0.012,
+    min_recovery_ratio: float = 0.25,
+    max_horizon_hours: int = 48,   # internal hard cap — do not change lightly
+) -> tuple[bool, str]:
+    """
+    Returns (has_active_v, diagnostic_line_or_empty).
+    The diagnostic line (when non-empty) has the form:
+        V: 09:15(s38), 11:42(m61), 14:03(L29)
+    """
+```
+
+### Input expectations (v1)
+
+- `bars`: list of dicts in chronological order, each containing at minimum:
+  - `"ts"`: ISO-8601 string or datetime (the bar's close time)
+  - `"close"`: numeric price
+- The caller (bot strategy) is responsible for fetching the bars (via `/engine/history` or equivalent) with whatever `bar_size` and `hours` it considers relevant (up to 48 h). The detector will internally truncate to the hard 48-hour cap from the last bar.
+
+### Strength encoding (v1)
+
+Each reported trough uses the compact token `LetterRecovery%`:
+
+- **Letter (depth bucket)** — percentage drop from its reference peak to the trough, measured against the peak price:
+  - `s` : 0.8 % – 1.8 %  (small)
+  - `m` : 1.8 % – 3.5 %  (medium)
+  - `L` : > 3.5 %       (large)
+- **Number** — integer recovery ratio `(current_close - trough) / (peak - trough) * 100`
+
+Example:
+- `09:15(s38)` → small-depth V whose bottom was at 09:15, 38 % of the drop has been recovered.
+- `14:03(L29)` → large-depth V, only 29 % recovered so far (still early in the recovery leg).
+
+The thresholds above are starting values for v1 and are easy to adjust after live observation.
+
+### Flattish recoveries
+
+A trough qualifies for the diagnostic (and therefore blocks the S order) as soon as:
+- Its depth bucket is at least `s`, **and**
+- The recovery ratio from that trough to the current bar meets or exceeds `min_recovery_ratio`.
+
+No additional conditions on bar-to-bar slope, number of up bars, or volatility are applied. This satisfies the "even flattish recoveries" requirement.
+
+### Multiple scales
+
+Because the search examines the entire capped 48-hour slice and records every qualifying (peak, trough) pair that still shows sufficient recovery at call time, both short-horizon and long-horizon Vs appear naturally in the same diagnostic line without any pre-declared list of windows.
+
+### Diagnostics contract
+
+- When no active V-recovery exists inside the cap: the function returns `(False, "")`.
+- When one or more exist: the function returns `(True, "V: 09:15(s38), 11:42(m61), ...")`.
+- The line always uses the local/session time of the trough bar (HH:mm of the bar's timestamp).
+- The list is sorted by trough time (oldest first).
+
+The bot strategy that calls the detector is expected to:
+1. Log the diagnostic line at INFO level when it is non-empty.
+2. Skip the sell-to-open submission for this decision cycle.
+
+### 48-hour hard cap
+
+`MAX_HORIZON_HOURS = 48` is a module-level constant. The detector never reasons about bars older than this, even if the caller supplies a longer series. This bound makes the (deliberately heavy) search safe for an on-demand call.
+
+## Consequences
+
+### Positive
+- Single place owns the "do not short into V recovery" policy.
+- Rich operator-visible diagnostics on every attempted S order.
+- High recall by design; easy to tune later toward more precision if too many valid shorts are being suppressed.
+- Completely independent of all existing signal / regime machinery.
+
+### Risks / follow-ups
+- The initial depth and recovery thresholds are starting points only. Live MES / equity / futures data will be needed to calibrate them.
+- Deduplication of nearby troughs (micro-Vs inside a larger bottom) is deliberately minimal in v1. If the diagnostic becomes noisy we will add a "minimum separation" or "most significant trough per cluster" rule in a follow-up.
+- The same module will later expose an inverted-V helper for long-entry gating; the core logic is symmetric.
+
+## Implementation notes for reviewers
+
+- The module contains only standard library + `datetime` / `zoneinfo` (no numpy, pandas, scipy, or project signal libraries).
+- All logic is exercised via the returned diagnostic string and the boolean; there are no side effects.
+- A unit-test skeleton exercising the diagnostic formatter and the 48 h truncation is included in the PR.
+
+This ADR + the accompanying implementation constitute the CR candidate for the first production-ready version of the V-recovery gate.

--- a/ib_trader/bots/strategies/v_recovery.py
+++ b/ib_trader/bots/strategies/v_recovery.py
@@ -1,0 +1,218 @@
+"""On-demand V-recovery (and inverted-V) detector for entry gating.
+
+This module is deliberately independent of all existing pivot, fuzzy-line,
+regime, and trajectory-curve machinery in the project.
+
+It is intended to be called just-in-time by a bot strategy immediately
+before it submits a sell-to-open (or buy-to-open) order.
+
+The only public entry point for v1 is `detect_v_recoveries`.
+
+Design goals (per ADR 020):
+- Hard internal 48-hour horizon (never looks further back).
+- High recall: even slow / flattish recoveries after a material drop qualify.
+- Multiple simultaneous Vs at different scales are reported.
+- Rich operator diagnostics: every active trough time + strength token.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+# =============================================================================
+# Tunables for v1 (easy to adjust after live observation)
+# =============================================================================
+
+MAX_HORIZON = timedelta(hours=48)
+
+# Minimum drop from a reference peak to be considered a V at all.
+# 1.2 % is a reasonable starting floor for liquid instruments (MES, QQQ, etc.).
+MIN_DEPTH_PCT_DEFAULT = 0.012
+
+# Minimum fraction of that drop that must have been recovered by "now"
+# before we consider the recovery leg "active" for gating purposes.
+MIN_RECOVERY_RATIO_DEFAULT = 0.25
+
+# When multiple troughs are close together we keep only the first one
+# in each cluster. This value is in *bars*, not minutes (caller controls bar size).
+MIN_TROUGH_SEPARATION_BARS = 25
+
+
+def _parse_close(bar: dict[str, Any]) -> float:
+    """Robustly extract close price as float."""
+    val = bar.get("close") or bar.get("c")
+    if val is None:
+        raise ValueError("bar missing 'close' field")
+    return float(val)
+
+
+def _parse_ts(bar: dict[str, Any]) -> datetime:
+    """Parse bar timestamp. Accepts ISO string or datetime."""
+    raw = bar.get("ts") or bar.get("timestamp") or bar.get("time")
+    if raw is None:
+        raise ValueError("bar missing timestamp field ('ts' or 'timestamp')")
+
+    if isinstance(raw, datetime):
+        if raw.tzinfo is None:
+            return raw.replace(tzinfo=timezone.utc)
+        return raw.astimezone(timezone.utc)
+
+    # ISO-8601 string
+    s = str(raw).replace("Z", "+00:00")
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _strength_token(depth: float, recovery: float) -> str:
+    """
+    Encode the two dimensions of strength into a compact token.
+
+    depth   -> letter bucket (percentage drop from its own peak)
+    recovery -> integer percentage of that drop already recovered
+    """
+    if depth >= 0.035:
+        letter = "L"
+    elif depth >= 0.018:
+        letter = "m"
+    else:
+        letter = "s"
+    pct = max(0, min(100, int(round(recovery * 100))))
+    return f"{letter}{pct}"
+
+
+def detect_v_recoveries(
+    bars: list[dict[str, Any]],
+    *,
+    min_depth_pct: float = MIN_DEPTH_PCT_DEFAULT,
+    min_recovery_ratio: float = MIN_RECOVERY_RATIO_DEFAULT,
+) -> tuple[bool, str]:
+    """
+    Detect active V-recoveries inside the supplied bar series.
+
+    The detector first truncates the series to the internal 48-hour hard cap
+    measured backwards from the last bar. It then searches for every
+    (peak, trough) pair that still shows a material recovery at the end of
+    the series.
+
+    Returns
+    -------
+    (has_active_v, diagnostic_line)
+        has_active_v is True if at least one qualifying trough exists.
+        diagnostic_line is either the empty string or a line of the form:
+            "V: 09:15(s38), 11:42(m61), 14:03(L29)"
+        Times are HH:mm of the trough bar (UTC or whatever tz the bars carry).
+
+    The detector is intentionally high-recall and accepts slow / flattish
+    recoveries. The only two conditions for a trough to appear are:
+      1. The drop from its reference peak was >= min_depth_pct, and
+      2. The price at the last bar has recovered >= min_recovery_ratio of that drop.
+    """
+    if len(bars) < 6:
+        return False, ""
+
+    # --- 1. Parse + apply 48 h hard cap (internal, not caller-controlled) ---
+    parsed: list[tuple[datetime, float]] = []
+    for b in bars:
+        try:
+            ts = _parse_ts(b)
+            close = _parse_close(b)
+            parsed.append((ts, close))
+        except Exception:
+            continue  # skip malformed bars silently (robust for live use)
+
+    if len(parsed) < 6:
+        return False, ""
+
+    last_ts = parsed[-1][0]
+    cutoff = last_ts - MAX_HORIZON
+    capped = [(ts, c) for ts, c in parsed if ts >= cutoff]
+
+    if len(capped) < 6:
+        return False, ""
+
+    n = len(capped)
+
+    # --- 2. Find candidate troughs (high-recall, multi-scale) ---
+    # For every bar i (except the very last few) we consider it a potential
+    # trough. We look back a generous but bounded window for the highest
+    # price before it. This naturally discovers Vs of many different lengths.
+    candidates: list[tuple[datetime, str, int]] = []
+
+    # Look back up to ~20 h worth of bars for the peak (gives good multi-scale
+    # coverage while staying O(n * 400) which is trivial for an on-demand call).
+    MAX_PEAK_LOOKBACK = 400
+
+    for i in range(3, n - 2):
+        lookback = min(MAX_PEAK_LOOKBACK, i)
+        peak_idx = max(range(i - lookback, i), key=lambda j: capped[j][1])
+        peak_price = capped[peak_idx][1]
+        trough_price = capped[i][1]
+
+        if peak_price <= 0 or trough_price >= peak_price:
+            continue
+
+        depth = (peak_price - trough_price) / peak_price
+        if depth < min_depth_pct:
+            continue
+
+        # Recovery measured from THIS trough all the way to the final bar
+        current_price = capped[-1][1]
+        denom = peak_price - trough_price
+        recovery = (current_price - trough_price) / denom if denom > 0 else 0.0
+
+        if recovery >= min_recovery_ratio:
+            token = _strength_token(depth, recovery)
+            candidates.append((capped[i][0], token, i))
+
+    if not candidates:
+        return False, ""
+
+    # --- 3. Deduplicate nearby troughs (keep the earliest in each cluster) ---
+    # This prevents the diagnostic from being spammed by 8 micro-troughs
+    # inside a 15-minute choppy bottom.
+    candidates.sort(key=lambda x: x[2])  # by bar index
+    kept: list[tuple[datetime, str]] = []
+    last_idx = -10_000
+
+    for ts, token, idx in candidates:
+        if idx - last_idx >= MIN_TROUGH_SEPARATION_BARS:
+            kept.append((ts, token))
+            last_idx = idx
+
+    if not kept:
+        return False, ""
+
+    # --- 4. Build the diagnostic line (oldest trough first) ---
+    kept.sort(key=lambda x: x[0])
+    parts = []
+    for ts, token in kept:
+        hhmm = ts.strftime("%H:%M")
+        parts.append(f"{hhmm}({token})")
+
+    diagnostic = "V: " + ", ".join(parts)
+    return True, diagnostic
+
+
+# -----------------------------------------------------------------------------
+# Symmetric helper for long entries (inverted V / recovery from a top)
+# Will be implemented in the same style once the short-side behaviour is
+# validated. For now the stub makes the import site future-proof.
+# -----------------------------------------------------------------------------
+
+def detect_inverted_v_recoveries(
+    bars: list[dict[str, Any]],
+    *,
+    min_depth_pct: float = MIN_DEPTH_PCT_DEFAULT,
+    min_recovery_ratio: float = MIN_RECOVERY_RATIO_DEFAULT,
+) -> tuple[bool, str]:
+    """
+    Placeholder for the inverted-V (recovery from a sharp top) detector.
+    Same contract as detect_v_recoveries but for "do not go long here".
+    Implementation will be added after the short-side version has bake time.
+    """
+    # For the initial CR we return "no inverted V" so existing call sites
+    # that want to be defensive can already import the name.
+    return False, ""


### PR DESCRIPTION
## Summary

New **high-recall, on-demand V-recovery detector** that a bot strategy can call immediately before submitting a sell-to-open (short) order.

- Hard internal **48-hour** horizon (configured inside the module).
- Detects **multiple** active V-recoveries at different scales inside the window.
- Explicitly supports **flattish / slow recoveries** (no momentum or steep-bounce requirements).
- Produces rich operator diagnostics:
  ```
  V: 09:15(s38), 11:42(m61), 14:03(L29)
  ```
  Each token shows the trough time + strength (depth bucket + recovery percentage).

## Design Document

Full specification, rationale, and v1 contracts are in the accompanying ADR:

**docs/decisions/020-v-recovery-detector.md**

The implementation is a fresh, zero-dependency module:

**ib_trader/bots/strategies/v_recovery.py**

It is completely independent of all existing pivot/fuzzy/regime/trajectory code.

## Intended Call Site

```python
from ib_trader.bots.strategies.v_recovery import detect_v_recoveries

has_v, diag = detect_v_recoveries(recent_bars_from_history)
if has_v:
    logger.info("V-recovery gate blocked short: %s", diag)
    return   # do not submit the S order
```

A stub for the inverted-V (long-entry) case is present for future symmetry.

## What to review

- Correctness of the peak/trough/recovery logic under the "flattish recovery" rule
- Strength token design (`s`/`m`/`L` + recovery %)
- 48 h hard-cap truncation
- Simple deduplication of nearby troughs (25-bar separation)
- Diagnostic formatting and timestamp handling
- Whether the starting thresholds are sane v1 defaults

This is the complete initial CR candidate. Thresholds and clustering will be tuned from live data.

